### PR TITLE
add since option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Lists stale branches that have mathinng prefix:
 git stale hotfix/ feature/
 ```
 
+Lists abandand branches for 3 months least in local repo:
+
+```
+git stale --since 3mo
+```
+
 ## Options
 
 ```
@@ -29,5 +35,25 @@ git stale -d [prefix...]
 git stale -d -f [prefix...]
 ```
 
-- `-d`, `--delete`: remove gone branches.
+- `-d`, `--delete`: remove selected branches.
 - `-f`, `--force`: combined with `-d`, remove branches even if it wasn't merged.
+- `--since <date>`: select branches which have older last commit date, instead selecting gone branches. Check out relative date format section.
+
+As default, this command selects "gone" branches.
+
+### Relative Date Format
+
+Some option in `git-stale` can accept relative date.
+
+- "1mo 2days" will be 1 month and 2 days.
+- "3y4w" will be 3 years and 1 month.
+
+Syntax in BNF is roughly described as below:
+
+```
+<period> ::= [<digits> <year-suffix>] [<digits> <month-suffix>] [<digits> <week-suffix>] [<digits> <day-suffix>]
+<year-suffix> ::= "y" | "yr" | "yrs" | "year" | "years"
+<month-suffix> ::= "mo" | "month" | "months"
+<week-suffix> ::= "w" | "week" | "weeks"
+<day-suffix> ::= "d" | "day" | "days"
+```

--- a/git/branches_test.go
+++ b/git/branches_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/oakcask/git-stale/git/cli"
 )
@@ -22,6 +23,11 @@ func (c *fakeCommand) Run(args ...string) error {
 	return c.err
 }
 
+func stdISO8601(s string) time.Time {
+	t, _ := time.Parse("20060102T150405-0700", s)
+	return t
+}
+
 func TestGit_GetBranches(t *testing.T) {
 	testCases := []struct {
 		command     fakeCommand
@@ -29,29 +35,33 @@ func TestGit_GetBranches(t *testing.T) {
 	}{
 		{
 			fakeCommand{
-				out: `a, gone
-b, behind 1
-c, behind 1, ahead 2
-d
+				out: `a, Thu Feb 4 20:38:23 2021 +0900, gone
+b, Tue Mar 30 22:22:02 2021 +0900, behind 1
+c, Fri Apr 23 17:36:01 2021 +0900, behind 1, ahead 2
+d, Thu Jun 10 08:12:17 2021 +0900, 
 `,
 				err: nil,
 			},
 			[]Branch{
 				{
-					Name: RefName("a"),
-					Gone: true,
+					Name:       RefName("a"),
+					Gone:       true,
+					CommitDate: stdISO8601("20210204T203823+0900"),
 				},
 				{
-					Name: RefName("b"),
-					Gone: false,
+					Name:       RefName("b"),
+					Gone:       false,
+					CommitDate: stdISO8601("20210330T222202+0900"),
 				},
 				{
-					Name: RefName("c"),
-					Gone: false,
+					Name:       RefName("c"),
+					Gone:       false,
+					CommitDate: stdISO8601("20210423T173601+0900"),
 				},
 				{
-					Name: RefName("d"),
-					Gone: false,
+					Name:       RefName("d"),
+					Gone:       false,
+					CommitDate: stdISO8601("20210610T081217+0900"),
 				},
 			},
 		},

--- a/git/git.go
+++ b/git/git.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/oakcask/git-stale/git/cli"
 )
@@ -12,8 +13,9 @@ type Git interface {
 }
 
 type Branch struct {
-	Name RefName
-	Gone bool
+	Name       RefName
+	Gone       bool
+	CommitDate time.Time
 }
 
 type RefName string

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/oakcask/git-stale
 
 go 1.16
+
+require github.com/oakcask/go-since v0.0.0-20220126113315-67ccc7f02985

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/oakcask/go-since v0.0.0-20220126113315-67ccc7f02985 h1:OnL+azxmKIq6U67rBXsAguXRi3qpsly5DQrKIufnWVM=
+github.com/oakcask/go-since v0.0.0-20220126113315-67ccc7f02985/go.mod h1:aS2VnbakcKiwcsMNit70il1IdxmMyxpqFx2WK0mv9cc=


### PR DESCRIPTION
Allow passing `--since` option that specifies date by yyyy-mm-dd or relative date like "3mo" "2weeks" etc., then git-stale shows branches with older committer date than the specified date, instead of gone branches.