### PR TITLE
allow accepting `--push` to remove remote branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ Lists stale branches that have mathinng prefix:
 git stale hotfix/ feature/
 ```
 
-Lists abandand branches for 3 months least in local repo:
+Show local abandand branches at least 3 months passed, then do `git push --delete` for them:
 
 ```
 git stale --since 3mo
+git stale --since 3mo --delete --push
 ```
 
 ## Options
@@ -33,11 +34,14 @@ git stale --since 3mo
 git stale [prefix...]
 git stale -d [prefix...]
 git stale -d -f [prefix...]
+git stale --push -d [-f] [prefix...]
 ```
 
 - `-d`, `--delete`: remove selected branches.
 - `-f`, `--force`: combined with `-d`, remove branches even if it wasn't merged.
 - `--since <date>`: select branches which have older last commit date, instead selecting gone branches. Check out relative date format section.
+- `--push`: combined with `-d`, invokes `git push --delete` instead removing local branches.
+  `--force` also be passed to `git push` if `-f` is specified.
 
 As default, this command selects "gone" branches.
 

--- a/git/branches.go
+++ b/git/branches.go
@@ -12,7 +12,7 @@ func (git *git) GetBranches() ([]Branch, error) {
 	// HACK: :track,nobracket will return string like "ahead 1, behind 2"
 	// so using ", " as delimiter between refname and upstream enables us to
 	// split these parts by ", ".
-	out, e := git.command.Call("branch", "--format", "%(refname:short), %(committerdate), %(upstream:track,nobracket)")
+	out, e := git.command.Call("branch", "--format", "%(refname:short), %(committerdate), %(upstream:remotename), %(upstream:track,nobracket)")
 	if e != nil {
 		return nil, e
 	}
@@ -33,20 +33,23 @@ func (git *git) GetBranches() ([]Branch, error) {
 			return nil, fmt.Errorf("unexpected date time format returned from git: %v", fields[1])
 		}
 
-		gone := len(fields) == 3 && fields[2] == "gone"
+		remoteName := fields[2]
+
+		gone := len(fields) == 4 && fields[3] == "gone"
 
 		branches = append(branches,
 			Branch{
 				Name:       RefName(fields[0]),
 				Gone:       gone,
 				CommitDate: commitDate,
+				RemoteName: remoteName,
 			})
 	}
 
 	return branches, nil
 }
 
-func (git *git) RemoveBranches(force bool, branches ...RefName) error {
+func (git *git) RemoveBranches(force bool, branches ...Branch) error {
 	if len(branches) == 0 {
 		return nil
 	}
@@ -55,9 +58,48 @@ func (git *git) RemoveBranches(force bool, branches ...RefName) error {
 	if force {
 		args = append(args, "-f")
 	}
-	for _, ref := range branches {
-		args = append(args, ref.String())
+	for _, branch := range branches {
+		args = append(args, branch.Name.String())
 	}
 
 	return git.command.Run(args...)
+}
+
+func (git *git) RemoveRemoteBranches(force bool, branches ...Branch) error {
+	if len(branches) == 0 {
+		return nil
+	}
+
+	branchesWillBePush := make(map[string][]RefName)
+	remotes := []string{}
+
+	for _, branch := range branches {
+		if branch.RemoteName != "" {
+			if len(branchesWillBePush[branch.RemoteName]) == 0 {
+				remotes = append(remotes, branch.RemoteName)
+			}
+			branchesWillBePush[branch.RemoteName] = append(branchesWillBePush[branch.RemoteName], branch.Name)
+		}
+	}
+
+	for _, remote := range remotes {
+		refs := branchesWillBePush[remote]
+		args := []string{"push", "--delete"}
+		if force {
+			args = append(args, "-f")
+		}
+
+		args = append(args, remote)
+
+		for _, ref := range refs {
+			args = append(args, ref.String())
+		}
+
+		err := git.command.Run(args...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/git/git.go
+++ b/git/git.go
@@ -9,13 +9,15 @@ import (
 
 type Git interface {
 	GetBranches() ([]Branch, error)
-	RemoveBranches(force bool, refnames ...RefName) error
+	RemoveBranches(force bool, branches ...Branch) error
+	RemoveRemoteBranches(force bool, branches ...Branch) error
 }
 
 type Branch struct {
 	Name       RefName
 	Gone       bool
 	CommitDate time.Time
+	RemoteName string
 }
 
 type RefName string


### PR DESCRIPTION
Add `--push` option.
Combined with `-d`, it will invoke `git push --delete` instead removing local branches.
`--force` also be passed to `git push` if `-f` is specified.